### PR TITLE
feat(DataLoaderKey): add Schema.Types.ObjectId type for DataLoaderKey

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import { Types } from 'mongoose';
+import { Schema, Types } from 'mongoose';
 
-export type DataLoaderKey = string | Types.ObjectId;
+export type DataLoaderKey = string | Types.ObjectId | Schema.Types.ObjectId;
 
 export type BuiltConditionSet = {
   conditions: any;


### PR DESCRIPTION
## Why?

When creating a Schema that has a `ref`, mongoose asks to use `Schema.Types.ObjectId` as the field type. But that shows a TS error when using a loader in a `resolve` it . For example:

On the model:

```ts
const AccountSchema = new mongoose.Schema<IAccount>(
  {
    balance: {
      type: Number,
      description: 'Balance amount from account',
    },
    user: {
      type: Schema.Types.ObjectId,
      ref: 'user',
      required: true,
      description: 'The owner of this account',
    },
  },
  {
    collection: 'Account',
    timestamps: true,
  }
);
```

The `resolve` that returns an error:

```ts
resolve: async (account, _, ctx) => {
  return UserLoader.load(ctx, account.user);
}
```

Because:
- `load(_ key)`: `key` accepts `Types.ObjectId`
- The `user` ref field on the Schema must be `Schema.Types.ObjectId`
- `Schema.Types.ObjectId` and `Types.ObjectId` are incompatible
